### PR TITLE
Grabbing label in queries and adding URL in xsl

### DIFF
--- a/queries/dco_comm_publications_limit_feb2015.rq
+++ b/queries/dco_comm_publications_limit_feb2015.rq
@@ -63,8 +63,8 @@ WHERE {
   OPTIONAL { ?articleID vivo:hasPublicationVenue/rdfs:label ?Journal }
   OPTIONAL { ?articleID dco:yearOfPublication ?year }
   OPTIONAL { ?articleID bibo:doi ?doi }
-  OPTIONAL { ?articleID dco:hasDcoId ?dcoId }
-  BIND (str(?dcoId) AS ?DCO_ID)
+  OPTIONAL { ?articleID dco:hasDcoId ?dcoId . ?dcoId rdfs:label ?dcoId_l . }
+  BIND (str(?dcoId_l) AS ?DCO_ID)
   BIND (str(?doi) as ?DOI1 )
   BIND (str(?doi) as ?DOI2 )
   BIND (str(?year) as ?Year )

--- a/queries/dco_comm_publications_nolimit_feb2015.rq
+++ b/queries/dco_comm_publications_nolimit_feb2015.rq
@@ -63,8 +63,8 @@ WHERE {
   OPTIONAL { ?articleID vivo:hasPublicationVenue/rdfs:label ?Journal }
   OPTIONAL { ?articleID dco:yearOfPublication ?year }
   OPTIONAL { ?articleID bibo:doi ?doi }
-  OPTIONAL { ?articleID dco:hasDcoId ?dcoId }
-  BIND (str(?dcoId) AS ?DCO_ID)
+  OPTIONAL { ?articleID dco:hasDcoId ?dcoId . ?dcoId rdfs:label ?dcoId_l . }
+  BIND (str(?dcoId_l) AS ?DCO_ID)
   BIND (str(?doi) as ?DOI1 )
   BIND (str(?doi) as ?DOI2 )
   BIND (str(?year) as ?Year )

--- a/queries/dco_dataset_citation.rq
+++ b/queries/dco_dataset_citation.rq
@@ -63,10 +63,10 @@ WHERE
 
     OPTIONAL { <?=$instance?> vivo:dateTimeValue [vivo:dateTime ?date] .}
     OPTIONAL { <?=$instance?> dco:yearOfPublication ?year .}
-    OPTIONAL { <?=$instance?> dco:hasDcoId ?dcoId .}
+    OPTIONAL { <?=$instance?> dco:hasDcoId ?dcoId . ?dcoId rdfs:label ?dcoId_l }
     OPTIONAL { <?=$instance?> vitro:modTime ?modDate .}
     BIND (str(?modDate) AS ?ModDate)
-    BIND (str(?dcoId) AS ?DCO_ID)    
+    BIND (str(?dcoId_l) AS ?DCO_ID)    
     BIND (str(?title) AS ?Title)
     BIND (str(?date) AS ?Date)
     BIND (str(?year) AS ?Year)    

--- a/queries/dco_dataset_citedby_full.rq
+++ b/queries/dco_dataset_citedby_full.rq
@@ -57,7 +57,7 @@ WHERE {
       {{ ?dcoAuthorID rdfs:label ?dcoAuthor .} UNION 
       { OPTIONAL { ?citedBy dco:authorName ?dcoAuthor }}}
       OPTIONAL { ?citedBy bibo:doi ?doi }
-      OPTIONAL { ?citedBy dco:hasDcoId ?dcoId }
+      OPTIONAL { ?citedBy dco:hasDcoId ?dcoId . ?dcoId rdfs:label ?dcoId_l . }
       OPTIONAL { ?citedBy bibo:presentedAt [rdfs:label ?event]}
       BIND (str(?article) AS ?Article )
       BIND (str(?journal) AS ?Journal )
@@ -66,7 +66,7 @@ WHERE {
       BIND (str(?dcoAuthor) as ?dco_author )
       BIND (str(?doi) as ?DOI1 )
       BIND (str(?doi) as ?DOI2 )
-      BIND (str(?dcoId) as ?DCO_ID )
+      BIND (str(?dcoId_l) as ?DCO_ID )
 }
 GROUP BY ?Article ?DOI1 ?Journal ?Year ?Event ?DOI2 ?DCO_ID
 ORDER BY DESC(?Year) 

--- a/queries/dco_dataset_dcocontributor_id.rq
+++ b/queries/dco_dataset_dcocontributor_id.rq
@@ -59,9 +59,10 @@ WHERE
     OPTIONAL { ?authorship vivo:rank ?rank . }
     ?contrib_id rdf:type foaf:Person ;
                 dco:hasDcoId ?dcoId .
-    ?contrib_id rdfs:label ?contrib_name
+    ?dcoId rdfs:label ?dcoId_l .
+    ?contrib_id rdfs:label ?contrib_name .
     BIND(str(?contrib_name) AS ?DCO_Contributor)
-    BIND(str(?dcoId) AS ?DCO_ID)
+    BIND(str(?dcoId_l) AS ?DCO_ID)
 } ORDER BY ?rank
 
 

--- a/queries/dco_dataset_dcoid.rq
+++ b/queries/dco_dataset_dcoid.rq
@@ -51,7 +51,7 @@ PREFIX vivo: <http://vivoweb.org/ontology/core#>
 SELECT ?DCO_ID
 WHERE
 {
-      OPTIONAL { <?=$instance?> dco:hasDcoId ?dcoId }
-      BIND(str(?dcoId) AS ?DCO_ID)
+      OPTIONAL { <?=$instance?> dco:hasDcoId ?dcoId . ?dcoId rdfs:label ?dcoId_l . }
+      BIND(str(?dcoId_l) AS ?DCO_ID)
 }
 

--- a/queries/dco_datasets.rq
+++ b/queries/dco_datasets.rq
@@ -53,13 +53,13 @@ WHERE {
 ?dataset a dco:Object ;
         rdfs:label ?l ;
         vitro:mostSpecificType [rdfs:label "Dataset"@en-US] .
-      OPTIONAL { ?dataset dco:hasDcoId ?id . }
+      OPTIONAL { ?dataset dco:hasDcoId ?dcoId . ?dcoId rdfs:label ?dcoId_l . }
       OPTIONAL { ?dataset dco:hasDistribution ?dist_id .}
       OPTIONAL { ?dataset vivo:description ?descrip .}
       OPTIONAL { ?dataset dco:associatedDCOCommunity [rdfs:label ?community] }
       BIND(str(?community) AS ?DCO_Community)
       BIND(str(?l) AS ?Title) .
-      BIND(str(?id) AS ?DCO_ID) .
+      BIND(str(?dcoId_l) AS ?DCO_ID) .
       BIND(str(?descrip) AS ?Description) .
       BIND(str(?dataset) AS ?dataset2) .
 } ORDER BY DESC(?DCO_Community)

--- a/queries/dco_inst_communities.rq
+++ b/queries/dco_inst_communities.rq
@@ -51,8 +51,8 @@ WHERE
 <http://info.deepcarbon.net/schema#associatedDCOCommunity> 
 ?associatedDCOCommunity .
       ?associatedDCOCommunity rdfs:label ?communityTitle .
-      OPTIONAL { ?associatedDCOCommunity dco:hasDcoId ?dcoId }
-      BIND(str(?dcoId) AS ?DCO_ID)
+      OPTIONAL { ?associatedDCOCommunity dco:hasDcoId ?dcoId . ?dcoId rdfs:label ?dcoId_l }
+      BIND(str(?dcoId_l) AS ?DCO_ID)
       BIND(str(?associatedDCOCommunity) AS ?Community_URI)
       BIND(str(?communityTitle) AS ?Associated_Community)
 }

--- a/queries/dco_inst_dcoid.rq
+++ b/queries/dco_inst_dcoid.rq
@@ -50,5 +50,6 @@ SELECT ?DCO_ID
 WHERE
 {
       <?=$instance?> dco:hasDcoId ?dcoId .
-      BIND(str(?dcoId) AS ?DCO_ID)
+      ?dcoId rdfs:label ?dcoId_l .
+      BIND(str(?dcoId_l) AS ?DCO_ID)
 }

--- a/queries/dco_inst_grants.rq
+++ b/queries/dco_inst_grants.rq
@@ -49,8 +49,8 @@ WHERE
 {
       <?=$instance?> vivo:hasFundingVehicle  ?grant .
       ?grant rdfs:label ?title .
-      OPTIONAL { ?grant dco:hasDcoId ?dcoId }
-      BIND(str(?dcoId) AS ?DCO_ID)
+      OPTIONAL { ?grant dco:hasDcoId ?dcoId . ?dcoId rdfs:label ?dcoId_l }
+      BIND(str(?dcoId_l) AS ?DCO_ID)
       BIND(str(?title) AS ?Related_Grants)
       BIND(str(?grant) AS ?Grant_URI)
 }

--- a/queries/dco_inst_relatedProjectUpdates.rq
+++ b/queries/dco_inst_relatedProjectUpdates.rq
@@ -51,8 +51,8 @@ WHERE
 <http://info.deepcarbon.net/schema#referencedByUpdate> 
 ?referencedByUpdate .
       ?referencedByUpdate rdfs:label ?updateTitle .
-      OPTIONAL { ?referencedByUpdate dco:hasDcoId ?dcoId }
-      BIND(str(?dcoId) AS ?DCO_ID)
+      OPTIONAL { ?referencedByUpdate dco:hasDcoId ?dcoId . ?dcoId rdfs:label ?dcoId_l }
+      BIND(str(?dcoId_l) AS ?DCO_ID)
       BIND(str(?referencedByUpdate) AS ?Update_URI)
       BIND(str(?updateTitle) AS ?Instrument_Referred_To_By)
 }

--- a/queries/dco_inst_relatedProjects.rq
+++ b/queries/dco_inst_relatedProjects.rq
@@ -49,8 +49,8 @@ WHERE
 {
        <?=$instance?>  <http://info.deepcarbon.net/schema#instrumentUsedBy> ?relatedProject .
       ?relatedProject rdfs:label ?relatedTitle .
-      OPTIONAL { ?relatedProject dco:hasDcoId ?dcoId }
-      BIND(str(?dcoId) AS ?DCO_ID)
+      OPTIONAL { ?relatedProject dco:hasDcoId ?dcoId . ?dcoId rdfs:label ?dcoId_l }
+      BIND(str(?dcoId_l) AS ?DCO_ID)
       BIND(str(?relatedProject) AS ?Project_URI)
       BIND(str(?relatedTitle) AS ?Instrument_Used_By)
 }

--- a/queries/dco_inst_team.rq
+++ b/queries/dco_inst_team.rq
@@ -49,8 +49,8 @@ WHERE
 {
        <?=$instance?>  dco:associatedDCOTeam ?associatedDCOTeam .
       ?associatedDCOTeam rdfs:label ?teamTitle .
-      OPTIONAL { ?associatedDCOTeam dco:hasDcoId ?dcoId }
-      BIND(str(?dcoId) AS ?DCO_ID)
+      OPTIONAL { ?associatedDCOTeam dco:hasDcoId ?dcoId . ?dcoId rdfs:label ?dcoId_l }
+      BIND(str(?dcoId_l) AS ?DCO_ID)
       BIND(str(?associatedDCOTeam) AS ?Team_URI)
       BIND(str(?teamTitle) AS ?Associated_Team)
 }

--- a/queries/dco_proj_dcoid.rq
+++ b/queries/dco_proj_dcoid.rq
@@ -51,7 +51,7 @@ PREFIX vivo: <http://vivoweb.org/ontology/core#>
 SELECT ?DCO_ID
 WHERE
 {
-      OPTIONAL { <?=$instance?> dco:hasDcoId ?dcoId }
-      BIND(str(?dcoId) AS ?DCO_ID)
+      OPTIONAL { <?=$instance?> dco:hasDcoId ?dcoId . ?dcoId rdfs:label ?dcoId_l . }
+      BIND(str(?dcoId_l) AS ?DCO_ID)
 }
 LIMIT 20

--- a/queries/dco_proj_grants.rq
+++ b/queries/dco_proj_grants.rq
@@ -49,8 +49,8 @@ WHERE
 {
       <?=$instance?> vivo:hasFundingVehicle  ?grant .
       ?grant rdfs:label ?title .
-      OPTIONAL { ?grant dco:hasDcoId ?dcoId }
-      BIND(str(?dcoId) AS ?DCO_ID)
+      OPTIONAL { ?grant dco:hasDcoId ?dcoId . ?dcoId rdfs:label ?dcoId_l }
+      BIND(str(?dcoId_l) AS ?DCO_ID)
       BIND(str(?title) AS ?Related_Grants)
 }
 

--- a/queries/dco_proj_participants.rq
+++ b/queries/dco_proj_participants.rq
@@ -53,10 +53,11 @@ WHERE
                       rdfs:label ?roleName .
       ?participant dco:hasDcoId ?dcoId;
                       rdfs:label ?name .
+      ?dcoId rdfs:label ?dcoId_l .
       ?participant dco:inOrganization ?org2 .
       ?org2 rdfs:label ?organization .
       BIND(str(?roleName) AS ?Role)
-      BIND(str(?dcoId) AS ?DCO_ID)
+      BIND(str(?dcoId_l) AS ?DCO_ID)
       BIND(str(?name) AS ?Name)
       BIND(str(?organization) AS ?institution)
 }

--- a/queries/dco_proj_relatedDatasets.rq
+++ b/queries/dco_proj_relatedDatasets.rq
@@ -49,8 +49,8 @@ WHERE
 {
        <?=$instance?>  <http://info.deepcarbon.net/schema#relatedDataset> ?relatedDataset .
       ?relatedDataset rdfs:label ?relatedTitle .
-      OPTIONAL { ?relatedDataset dco:hasDcoId ?dcoId }
-      BIND(str(?dcoId) AS ?DCO_ID)
+      OPTIONAL { ?relatedDataset dco:hasDcoId ?dcoId . ?dcoId rdfs:label ?dcoId_l . }
+      BIND(str(?dcoId_l) AS ?DCO_ID)
       BIND(str(?relatedTitle) AS ?Related_Datasets)
 }
 ORDER BY DESC(?Related_Datasets)

--- a/queries/dco_proj_relatedProjects.rq
+++ b/queries/dco_proj_relatedProjects.rq
@@ -49,8 +49,8 @@ WHERE
 {
        <?=$instance?>  <http://info.deepcarbon.net/schema#relatedProject> ?relatedProject .
       ?relatedProject rdfs:label ?relatedTitle .
-      OPTIONAL { ?relatedProject dco:hasDcoId ?dcoId }
-      BIND(str(?dcoId) AS ?DCO_ID)
+      OPTIONAL { ?relatedProject dco:hasDcoId ?dcoId . ?dcoId rdfs:label ?dcoId_l . }
+      BIND(str(?dcoId_l) AS ?DCO_ID)
       BIND(str(?relatedProject) AS ?Project_URI)
       BIND(str(?relatedTitle) AS ?Related_Projects)
 }

--- a/queries/dco_proj_relatedPublications.rq
+++ b/queries/dco_proj_relatedPublications.rq
@@ -49,8 +49,8 @@ WHERE
 {
        <?=$instance?>  <http://purl.obolibrary.org/obo/RO_0002234> ?relatedOutput .
       ?relatedOutput rdfs:label ?relatedTitle .
-      OPTIONAL { ?relatedOutput dco:hasDcoId ?dcoId }
-      BIND(str(?dcoId) AS ?DCO_ID)
+      OPTIONAL { ?relatedOutput dco:hasDcoId ?dcoId . ?dcoId rdfs:label ?dcoId_l . }
+      BIND(str(?dcoId_l) AS ?DCO_ID)
       BIND(str(?relatedTitle) AS ?Related_Publications)
 }
 ORDER BY DESC(?Related_Publications)

--- a/xslt/dataset_citation.xsl
+++ b/xslt/dataset_citation.xsl
@@ -1,11 +1,11 @@
 <?xml version="1.0"?>
 
 <xsl:stylesheet version="1.0"
-		xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-		xmlns="http://www.w3.org/1999/xhtml"
-		xmlns:res="http://www.w3.org/2005/sparql-results#"
-		xmlns:fn="http://www.w3.org/2005/xpath-functions"
-		exclude-result-prefixes="res xsl">
+        xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+        xmlns="http://www.w3.org/1999/xhtml"
+        xmlns:res="http://www.w3.org/2005/sparql-results#"
+        xmlns:fn="http://www.w3.org/2005/xpath-functions"
+        exclude-result-prefixes="res xsl">
 
 <xsl:template match="/">
  <div style="width:95%">
@@ -17,7 +17,7 @@
       <xsl:variable name="uri-value">
         <xsl:value-of select="res:literal"/>
       </xsl:variable>
-     <a href="{$uri-value}"><xsl:value-of select="res:literal"/></a>
+     <a href="https://dx.deepcarbon.net/{$uri-value}"><xsl:value-of select="res:literal"/></a>
     </xsl:if>
      <xsl:if test="@name='Date'">
       <xsl:value-of select="substring(res:literal, 1, 4)"/><xsl:text>. </xsl:text>

--- a/xslt/dataset_citedby.xsl
+++ b/xslt/dataset_citedby.xsl
@@ -16,7 +16,7 @@
       <xsl:variable name="uri-value">
         <xsl:value-of select="res:literal"/>
       </xsl:variable>
-     <a href="{$uri-value}"><xsl:value-of select="res:literal"/></a>
+     <a href="https://dx.deepcarbon.net/{$uri-value}"><xsl:value-of select="res:literal"/></a>
     </xsl:if>
     <xsl:if test="@name='Article'">
       <br /><strong><xsl:text>Cited by: </xsl:text></strong><xsl:value-of select="res:literal" disable-output-escaping="yes"/><xsl:text>. </xsl:text>

--- a/xslt/dco_grant_accordion_style.xsl
+++ b/xslt/dco_grant_accordion_style.xsl
@@ -16,7 +16,7 @@
       <xsl:variable name="uri-value">
         <xsl:value-of select="following-sibling::res:binding/res:literal"/>
       </xsl:variable>
-     <a href="http://deepcarbon.net/dco_grant_summary?uri={$uri-value}"><xsl:value-of select="res:literal"/></a></p>
+     <a href="/dco_grant_summary?uri={$uri-value}"><xsl:value-of select="res:literal"/></a></p>
     </xsl:if>
   </xsl:for-each>
    <div>
@@ -40,7 +40,7 @@
      <xsl:variable name="uri-value">
         <xsl:value-of select="following-sibling::res:binding/res:literal"/>
       </xsl:variable>
-     <a href="http://deepcarbon.net/dco_project_summary?uri={$uri-value}"><xsl:value-of select="res:literal"/></a></h3>
+     <a href="/dco_project_summary?uri={$uri-value}"><xsl:value-of select="res:literal"/></a></h3>
      <xsl:text>&#xa;</xsl:text>
     </xsl:if>
     </p>

--- a/xslt/dco_proj_accordion_style.xsl
+++ b/xslt/dco_proj_accordion_style.xsl
@@ -16,7 +16,7 @@
       <xsl:variable name="uri-value">
         <xsl:value-of select="following-sibling::res:binding/res:literal"/>
       </xsl:variable>
-     <a href="http://deepcarbon.net/dco_project_summary?uri={$uri-value}"><xsl:value-of select="res:literal"/></a></h3>
+     <a href="/dco_project_summary?uri={$uri-value}"><xsl:value-of select="res:literal"/></a></h3>
     </xsl:if>
   </xsl:for-each>
    <div>
@@ -40,7 +40,7 @@
       </xsl:variable>
       <xsl:choose>
         <xsl:when test="starts-with($uri-value,'http:') or starts-with($uri-value,'https:')">
-	  <a href="http://deepcarbon.net/dco_project_summary?uri={$uri-value}"><strong><xsl:text>Details...</xsl:text></strong></a>
+	  <a href="/dco_project_summary?uri={$uri-value}"><strong><xsl:text>Details...</xsl:text></strong></a>
 	</xsl:when>
       <xsl:otherwise>
       </xsl:otherwise>

--- a/xslt/dco_publications_xform_new.xsl
+++ b/xslt/dco_publications_xform_new.xsl
@@ -28,7 +28,7 @@
    <xsl:for-each select="res:binding"> 
      <xsl:if test="@name='DCO_ID'">
       <xsl:variable name="dcoid-value"> <xsl:value-of select="res:literal" disable-output-escaping="yes"/> </xsl:variable>
-      <a href="{$dcoid-value}"><xsl:text>Publication Metadata</xsl:text></a>
+      <a href="https://dx.deepcarbon.net/{$dcoid-value}"><xsl:text>Publication Metadata</xsl:text></a>
      </xsl:if>
      <xsl:if test="@name='DOI2'">
       <xsl:variable name="doi-value-2"> <xsl:value-of select="res:literal" disable-output-escaping="yes"/> </xsl:variable>

--- a/xslt/dco_publications_xform_new_long.xsl
+++ b/xslt/dco_publications_xform_new_long.xsl
@@ -37,7 +37,7 @@
    <xsl:for-each select="res:binding"> 
      <xsl:if test="@name='DCO_ID'">
       <xsl:variable name="dcoid-value"> <xsl:value-of select="res:literal" disable-output-escaping="yes"/> </xsl:variable>
-      <a href="{$dcoid-value}"><xsl:text>Publication Metadata.</xsl:text></a>
+      <a href="https://dx.deepcarbon.net/{$dcoid-value}"><xsl:text>Publication Metadata.</xsl:text></a>
      </xsl:if>
      <xsl:if test="@name='DOI2'">
       <xsl:variable name="doi-value-2"> <xsl:value-of select="res:literal" disable-output-escaping="yes"/> </xsl:variable>

--- a/xslt/field_studies_transform_4.xsl
+++ b/xslt/field_studies_transform_4.xsl
@@ -16,7 +16,7 @@
       <xsl:variable name="uri-value">
         <xsl:value-of select="following-sibling::res:binding/res:literal"/>
       </xsl:variable>
-     <a href="http://deepcarbon.net/dco_field_study_summary?uri={$uri-value}"><xsl:value-of select="res:literal"/></a><xsl:comment> EOD proj_title </xsl:comment></div>
+     <a href="/dco_field_study_summary?uri={$uri-value}"><xsl:value-of select="res:literal"/></a><xsl:comment> EOD proj_title </xsl:comment></div>
     </xsl:if>
   </xsl:for-each>
    <div class="proj_details">

--- a/xslt/field_study_siblings_transform.xsl
+++ b/xslt/field_study_siblings_transform.xsl
@@ -27,7 +27,7 @@
       <xsl:variable name="uri-value">
         <xsl:value-of select="following-sibling::res:binding/res:literal"/>
       </xsl:variable>
-     <a href="http://deepcarbon.net/dco_field_study_summary?uri={$uri-value}"><xsl:value-of select="res:literal"/></a></strong></li>
+     <a href="/dco_field_study_summary?uri={$uri-value}"><xsl:value-of select="res:literal"/></a></strong></li>
     </xsl:if>
   </xsl:for-each>
  </xsl:for-each>

--- a/xslt/foo.xsl
+++ b/xslt/foo.xsl
@@ -118,7 +118,14 @@ Fix:
 	    <a href="{$cell-value}"><xsl:value-of select="$cell-value"/></a>
 	  </xsl:when>
       <xsl:otherwise>
-	    <xsl:value-of select="$cell-value"/>
+        <xsl:choose>
+          <xsl:when test="starts-with($cell-value,'11121')">
+            <a href="https://dx.deepcarbon.net/{$cell-value}"><xsl:value-of select="$cell-value"/></a>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="$cell-value"/>
+          </xsl:otherwise>
+        </xsl:choose>
       </xsl:otherwise>
     </xsl:choose>
 

--- a/xslt/instrument_transform_4.xsl
+++ b/xslt/instrument_transform_4.xsl
@@ -16,7 +16,7 @@
       <xsl:variable name="uri-value">
         <xsl:value-of select="following-sibling::res:binding/res:literal"/>
       </xsl:variable>
-     <a href="http://deepcarbon.net/dco_instrument_summary?uri={$uri-value}"><xsl:value-of select="res:literal"/></a><xsl:comment> EOD proj_title </xsl:comment></div>
+     <a href="/dco_instrument_summary?uri={$uri-value}"><xsl:value-of select="res:literal"/></a><xsl:comment> EOD proj_title </xsl:comment></div>
     </xsl:if>
   </xsl:for-each>
    <div class="proj_details">

--- a/xslt/proj_siblings_transform.xsl
+++ b/xslt/proj_siblings_transform.xsl
@@ -27,7 +27,7 @@
       <xsl:variable name="uri-value">
         <xsl:value-of select="following-sibling::res:binding/res:literal"/>
       </xsl:variable>
-     <a href="http://deepcarbon.net/dco_project_summary?uri={$uri-value}"><xsl:value-of select="res:literal"/></a></strong></li>
+     <a href="/dco_project_summary?uri={$uri-value}"><xsl:value-of select="res:literal"/></a></strong></li>
     </xsl:if>
   </xsl:for-each>
  </xsl:for-each>

--- a/xslt/projects_transform_3.xsl
+++ b/xslt/projects_transform_3.xsl
@@ -16,7 +16,7 @@
       <xsl:variable name="uri-value">
         <xsl:value-of select="following-sibling::res:binding/res:literal"/>
       </xsl:variable>
-     <a href="http://deepcarbon.net/dco_project_summary?uri={$uri-value}"><xsl:value-of select="res:literal"/></a></h3>
+     <a href="/dco_project_summary?uri={$uri-value}"><xsl:value-of select="res:literal"/></a></h3>
     </xsl:if>
   </xsl:for-each>
    <div>
@@ -40,7 +40,7 @@
       </xsl:variable>
       <xsl:choose>
         <xsl:when test="starts-with($uri-value,'http:') or starts-with($uri-value,'https:')">
-	  <a href="http://deepcarbon.net/dco_project_summary?uri={$uri-value}"><strong><xsl:text>Details...</xsl:text></strong></a>
+	  <a href="/dco_project_summary?uri={$uri-value}"><strong><xsl:text>Details...</xsl:text></strong></a>
 	</xsl:when>
       <xsl:otherwise>
       </xsl:otherwise>

--- a/xslt/projects_transform_4.xsl
+++ b/xslt/projects_transform_4.xsl
@@ -16,7 +16,7 @@
       <xsl:variable name="uri-value">
         <xsl:value-of select="following-sibling::res:binding/res:literal"/>
       </xsl:variable>
-     <a href="http://deepcarbon.net/dco_project_summary?uri={$uri-value}"><xsl:value-of select="res:literal"/></a><xsl:comment> EOD proj_title </xsl:comment></div>
+     <a href="/dco_project_summary?uri={$uri-value}"><xsl:value-of select="res:literal"/></a><xsl:comment> EOD proj_title </xsl:comment></div>
     </xsl:if>
    </xsl:for-each>
    <div class="proj_details">

--- a/xslt/xml-to-html-cont.xsl
+++ b/xslt/xml-to-html-cont.xsl
@@ -125,7 +125,14 @@ Fix:
 	    <a href="{$cell-value}"><xsl:value-of select="$cell-value" disable-output-escaping="yes" /></a>
 	  </xsl:when>
       <xsl:otherwise>
-	    <xsl:value-of select="$cell-value" disable-output-escaping="yes" /> <xsl:text>, </xsl:text>
+        <xsl:choose>
+          <xsl:when test="starts-with($cell-value,'11121')">
+            <a href="https://dx.deepcarbon.net/{$cell-value}"><xsl:value-of select="$cell-value"/></a>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="$cell-value" disable-output-escaping="yes" /> <xsl:text>, </xsl:text>
+          </xsl:otherwise>
+        </xsl:choose>
       </xsl:otherwise>
     </xsl:choose>
 

--- a/xslt/xml-to-html-desc.xsl
+++ b/xslt/xml-to-html-desc.xsl
@@ -125,7 +125,14 @@ Fix:
 	    <a href="{$cell-value}"><xsl:value-of select="$cell-value" disable-output-escaping="yes" /></a>
 	  </xsl:when>
       <xsl:otherwise>
-	    <xsl:value-of select="$cell-value" disable-output-escaping="yes" />
+        <xsl:choose>
+          <xsl:when test="starts-with($cell-value,'11121')">
+            <a href="https://dx.deepcarbon.net/{$cell-value}"><xsl:value-of select="$cell-value"/></a>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="$cell-value" disable-output-escaping="yes" />
+          </xsl:otherwise>
+        </xsl:choose>
       </xsl:otherwise>
     </xsl:choose>
 

--- a/xslt/xml-to-html-statistics.xsl
+++ b/xslt/xml-to-html-statistics.xsl
@@ -91,7 +91,14 @@ Modified by Stephen Moon for DCO Statistics
 	    <a href="{$cell-value}"><xsl:value-of select="$cell-value" disable-output-escaping="yes" /></a>
 	  </xsl:when>
       <xsl:otherwise>
-	    <xsl:value-of select="$cell-value" disable-output-escaping="yes" />
+        <xsl:choose>
+          <xsl:when test="starts-with($cell-value,'11121')">
+            <a href="https://dx.deepcarbon.net/{$cell-value}"><xsl:value-of select="$cell-value"/></a>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="$cell-value" disable-output-escaping="yes" />
+          </xsl:otherwise>
+        </xsl:choose>
       </xsl:otherwise>
     </xsl:choose>
 

--- a/xslt/xml-to-html-title.xsl
+++ b/xslt/xml-to-html-title.xsl
@@ -118,7 +118,14 @@ Fix:
 	    <a href="{$cell-value}"><xsl:value-of select="$cell-value"/></a>
 	  </xsl:when>
       <xsl:otherwise>
-	    <xsl:value-of select="$cell-value"/>
+        <xsl:choose>
+          <xsl:when test="starts-with($cell-value,'11121')">
+            <a href="https://dx.deepcarbon.net/{$cell-value}"><xsl:value-of select="$cell-value"/></a>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="$cell-value"/>
+          </xsl:otherwise>
+        </xsl:choose>
       </xsl:otherwise>
     </xsl:choose>
 

--- a/xslt/xml-to-html.xsl
+++ b/xslt/xml-to-html.xsl
@@ -118,7 +118,14 @@ Fix:
 	    <a href="{$cell-value}"><xsl:value-of select="$cell-value"/></a>
 	  </xsl:when>
       <xsl:otherwise>
-	    <xsl:value-of select="$cell-value"/>
+        <xsl:choose>
+          <xsl:when test="starts-with($cell-value,'11121')">
+            <a href="https://dx.deepcarbon.net/{$cell-value}"><xsl:value-of select="$cell-value"/></a>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="$cell-value"/>
+          </xsl:otherwise>
+        </xsl:choose>
       </xsl:otherwise>
     </xsl:choose>
 


### PR DESCRIPTION
Was using the URI of the dcoid but this causes problems because it starts with a http: instead of https:. When clicking on the dco-id and you were logged in
it would log you out and force you to log back in (not chrome, chrome did the right thing). So grabbing the label now instead of the URI of the dcoid and
tacking on https://dx.deepcarbon.net/

Also changed a few xsl to use relative paths to the summary pages instead of full paths to make working in test environments easier.
