### PR TITLE
Breaking apart display of initiative summary page

### DIFF
--- a/xslt/concept-common.xsl
+++ b/xslt/concept-common.xsl
@@ -32,7 +32,7 @@
     <xsl:param name="entity"/>
     <xsl:choose>
       <xsl:when test="$entity/vivo:hasSubjectArea">
-        <p>Studies Of:
+        <p><span style="font-weight:bold;">Studies Of</span>:
         <xsl:for-each select="key('skos:Concept-nodes',$entity/vivo:hasSubjectArea/@rdf:resource)">
           <xsl:sort select="rdfs:label"/>
           <xsl:call-template name="place-concept-profile-link">

--- a/xslt/initiative-common.xsl
+++ b/xslt/initiative-common.xsl
@@ -26,7 +26,7 @@
   <xsl:template name="place-initiative-profile-link">
     <xsl:param name="initiative"/>
     <xsl:variable name="initiativeuri" select="$initiative/@rdf:resource|$initiative/@rdf:about"/>
-    <div><a href="{$initiativeuri}">Initiative Metadata</a></div>
+    <div><a href="{$initiativeuri}">Instrument Metadata</a></div>
   </xsl:template>
 
   <xsl:template name="place-instrument-profile-link">

--- a/xslt/instr_builts.xsl
+++ b/xslt/instr_builts.xsl
@@ -21,20 +21,21 @@
     <xsl:param name="built"/>
     <xsl:param name="root"/>
 
-    <blockquote>
+    <!--
     <h4 style="font-size:120%;"><xsl:value-of select="$built/rdfs:label"/></h4>
 
-    <xsl:call-template name="place-instrument-description">
-      <xsl:with-param name="instrument" select="$built"/>
-    </xsl:call-template>
 
     <xsl:call-template name="place-instrument-profile-link">
       <xsl:with-param name="instrument" select="$built"/>
     </xsl:call-template>
-
-    <xsl:call-template name="place-pocs">
-      <xsl:with-param name="entity" select="$built"/>
-    </xsl:call-template>
+    -->
+    <blockquote style="display:block;margin-top: 1em;margin-bottom: 1em;">
+      <xsl:call-template name="place-instrument-description">
+        <xsl:with-param name="instrument" select="$built"/>
+      </xsl:call-template>
+      <xsl:call-template name="place-pocs">
+        <xsl:with-param name="entity" select="$built"/>
+      </xsl:call-template>
     </blockquote>
 
   </xsl:template>

--- a/xslt/instr_initiative_areas.xsl
+++ b/xslt/instr_initiative_areas.xsl
@@ -21,7 +21,7 @@
   <xsl:import href="/xslt/pub-common.xsl"/>
   <xsl:import href="/xslt/concept-common.xsl"/>
 
-  <xsl:template name="instr_initiative">
+  <xsl:template name="instr_initiative_areas">
     <xsl:param name="admin"/>
     <xsl:param name="root"/>
 
@@ -29,53 +29,19 @@
       <xsl:when test="$root//dco:InstrumentInitiative[@rdf:about]|$root//*[rdf:type/@rdf:resource='&dco;InstrumentInitiative' and @rdf:about]">
         <xsl:variable name="initiative" select="$root//dco:InstrumentInitiative[@rdf:about]|$root//*[rdf:type/@rdf:resource='&dco;InstrumentInitiative' and @rdf:about]"/>
 
-        <xsl:call-template name="place-initiative-title">
-          <xsl:with-param name="initiative" select="$initiative"/>
-        </xsl:call-template>
-    
-        <div style="overflow: auto;">
-          <xsl:call-template name="place-image">
-            <xsl:with-param name="node" select="$initiative"/>
-            <xsl:with-param name="style" select='"max-width:30%;height:auto;float:left;margin:5px 1px;"'/>
-          </xsl:call-template>
-    
-          <xsl:call-template name="place-initiative-description">
-            <xsl:with-param name="initiative" select="$initiative"/>
-          </xsl:call-template>
-        </div>
-    
-        <div style="float:clear;">
-          <xsl:call-template name="place-initiative-profile-link">
-            <xsl:with-param name="initiative" select="$initiative"/>
-          </xsl:call-template>
-
-          <!--
-          <xsl:call-template name="place-webpages">
-            <xsl:with-param name="node" select="$initiative"/>
-          </xsl:call-template>
-    
-          <xsl:call-template name="place-dco-citation">
-            <xsl:with-param name="node" select="$initiative"/>
-          </xsl:call-template>
-    
-          <xsl:call-template name="place-news">
-            <xsl:with-param name="node" select="$initiative"/>
-          </xsl:call-template>
-    
           <xsl:call-template name="place-subject-areas">
             <xsl:with-param name="entity" select="$initiative"/>
           </xsl:call-template>
-          -->
-        </div>
+
       </xsl:when>
       <xsl:otherwise>
-        The requested Instrument Initiative does not exist
+        <xsl:text> </xsl:text>
       </xsl:otherwise>
     </xsl:choose>
   </xsl:template>
 
   <xsl:template match="/">
-    <xsl:call-template name="instr_initiative">
+    <xsl:call-template name="instr_initiative_areas">
       <xsl:with-param name="admin" select="false()"/>
       <xsl:with-param name="root" select="/rdf:RDF"/>
     </xsl:call-template>

--- a/xslt/instr_initiative_news.xsl
+++ b/xslt/instr_initiative_news.xsl
@@ -21,7 +21,7 @@
   <xsl:import href="/xslt/pub-common.xsl"/>
   <xsl:import href="/xslt/concept-common.xsl"/>
 
-  <xsl:template name="instr_initiative">
+  <xsl:template name="instr_initiative_news">
     <xsl:param name="admin"/>
     <xsl:param name="root"/>
 
@@ -29,53 +29,19 @@
       <xsl:when test="$root//dco:InstrumentInitiative[@rdf:about]|$root//*[rdf:type/@rdf:resource='&dco;InstrumentInitiative' and @rdf:about]">
         <xsl:variable name="initiative" select="$root//dco:InstrumentInitiative[@rdf:about]|$root//*[rdf:type/@rdf:resource='&dco;InstrumentInitiative' and @rdf:about]"/>
 
-        <xsl:call-template name="place-initiative-title">
-          <xsl:with-param name="initiative" select="$initiative"/>
-        </xsl:call-template>
-    
-        <div style="overflow: auto;">
-          <xsl:call-template name="place-image">
-            <xsl:with-param name="node" select="$initiative"/>
-            <xsl:with-param name="style" select='"max-width:30%;height:auto;float:left;margin:5px 1px;"'/>
-          </xsl:call-template>
-    
-          <xsl:call-template name="place-initiative-description">
-            <xsl:with-param name="initiative" select="$initiative"/>
-          </xsl:call-template>
-        </div>
-    
-        <div style="float:clear;">
-          <xsl:call-template name="place-initiative-profile-link">
-            <xsl:with-param name="initiative" select="$initiative"/>
-          </xsl:call-template>
-
-          <!--
-          <xsl:call-template name="place-webpages">
-            <xsl:with-param name="node" select="$initiative"/>
-          </xsl:call-template>
-    
-          <xsl:call-template name="place-dco-citation">
-            <xsl:with-param name="node" select="$initiative"/>
-          </xsl:call-template>
-    
           <xsl:call-template name="place-news">
             <xsl:with-param name="node" select="$initiative"/>
           </xsl:call-template>
-    
-          <xsl:call-template name="place-subject-areas">
-            <xsl:with-param name="entity" select="$initiative"/>
-          </xsl:call-template>
-          -->
-        </div>
+
       </xsl:when>
       <xsl:otherwise>
-        The requested Instrument Initiative does not exist
+        <xsl:text> </xsl:text>
       </xsl:otherwise>
     </xsl:choose>
   </xsl:template>
 
   <xsl:template match="/">
-    <xsl:call-template name="instr_initiative">
+    <xsl:call-template name="instr_initiative_news">
       <xsl:with-param name="admin" select="false()"/>
       <xsl:with-param name="root" select="/rdf:RDF"/>
     </xsl:call-template>

--- a/xslt/instr_initiative_pubs.xsl
+++ b/xslt/instr_initiative_pubs.xsl
@@ -21,7 +21,7 @@
   <xsl:import href="/xslt/pub-common.xsl"/>
   <xsl:import href="/xslt/concept-common.xsl"/>
 
-  <xsl:template name="instr_initiative">
+  <xsl:template name="instr_initiative_pubs">
     <xsl:param name="admin"/>
     <xsl:param name="root"/>
 
@@ -29,53 +29,19 @@
       <xsl:when test="$root//dco:InstrumentInitiative[@rdf:about]|$root//*[rdf:type/@rdf:resource='&dco;InstrumentInitiative' and @rdf:about]">
         <xsl:variable name="initiative" select="$root//dco:InstrumentInitiative[@rdf:about]|$root//*[rdf:type/@rdf:resource='&dco;InstrumentInitiative' and @rdf:about]"/>
 
-        <xsl:call-template name="place-initiative-title">
-          <xsl:with-param name="initiative" select="$initiative"/>
-        </xsl:call-template>
-    
-        <div style="overflow: auto;">
-          <xsl:call-template name="place-image">
+          <xsl:call-template name="place-dco-citations">
             <xsl:with-param name="node" select="$initiative"/>
-            <xsl:with-param name="style" select='"max-width:30%;height:auto;float:left;margin:5px 1px;"'/>
-          </xsl:call-template>
-    
-          <xsl:call-template name="place-initiative-description">
-            <xsl:with-param name="initiative" select="$initiative"/>
-          </xsl:call-template>
-        </div>
-    
-        <div style="float:clear;">
-          <xsl:call-template name="place-initiative-profile-link">
-            <xsl:with-param name="initiative" select="$initiative"/>
           </xsl:call-template>
 
-          <!--
-          <xsl:call-template name="place-webpages">
-            <xsl:with-param name="node" select="$initiative"/>
-          </xsl:call-template>
-    
-          <xsl:call-template name="place-dco-citation">
-            <xsl:with-param name="node" select="$initiative"/>
-          </xsl:call-template>
-    
-          <xsl:call-template name="place-news">
-            <xsl:with-param name="node" select="$initiative"/>
-          </xsl:call-template>
-    
-          <xsl:call-template name="place-subject-areas">
-            <xsl:with-param name="entity" select="$initiative"/>
-          </xsl:call-template>
-          -->
-        </div>
       </xsl:when>
       <xsl:otherwise>
-        The requested Instrument Initiative does not exist
+        <xsl:text> </xsl:text>
       </xsl:otherwise>
     </xsl:choose>
   </xsl:template>
 
   <xsl:template match="/">
-    <xsl:call-template name="instr_initiative">
+    <xsl:call-template name="instr_initiative_pubs">
       <xsl:with-param name="admin" select="false()"/>
       <xsl:with-param name="root" select="/rdf:RDF"/>
     </xsl:call-template>

--- a/xslt/instr_initiative_ws.xsl
+++ b/xslt/instr_initiative_ws.xsl
@@ -21,7 +21,7 @@
   <xsl:import href="/xslt/pub-common.xsl"/>
   <xsl:import href="/xslt/concept-common.xsl"/>
 
-  <xsl:template name="instr_initiative">
+  <xsl:template name="instr_initiative_ws">
     <xsl:param name="admin"/>
     <xsl:param name="root"/>
 
@@ -29,53 +29,19 @@
       <xsl:when test="$root//dco:InstrumentInitiative[@rdf:about]|$root//*[rdf:type/@rdf:resource='&dco;InstrumentInitiative' and @rdf:about]">
         <xsl:variable name="initiative" select="$root//dco:InstrumentInitiative[@rdf:about]|$root//*[rdf:type/@rdf:resource='&dco;InstrumentInitiative' and @rdf:about]"/>
 
-        <xsl:call-template name="place-initiative-title">
-          <xsl:with-param name="initiative" select="$initiative"/>
-        </xsl:call-template>
-    
-        <div style="overflow: auto;">
-          <xsl:call-template name="place-image">
-            <xsl:with-param name="node" select="$initiative"/>
-            <xsl:with-param name="style" select='"max-width:30%;height:auto;float:left;margin:5px 1px;"'/>
-          </xsl:call-template>
-    
-          <xsl:call-template name="place-initiative-description">
-            <xsl:with-param name="initiative" select="$initiative"/>
-          </xsl:call-template>
-        </div>
-    
-        <div style="float:clear;">
-          <xsl:call-template name="place-initiative-profile-link">
-            <xsl:with-param name="initiative" select="$initiative"/>
-          </xsl:call-template>
-
-          <!--
           <xsl:call-template name="place-webpages">
             <xsl:with-param name="node" select="$initiative"/>
           </xsl:call-template>
-    
-          <xsl:call-template name="place-dco-citation">
-            <xsl:with-param name="node" select="$initiative"/>
-          </xsl:call-template>
-    
-          <xsl:call-template name="place-news">
-            <xsl:with-param name="node" select="$initiative"/>
-          </xsl:call-template>
-    
-          <xsl:call-template name="place-subject-areas">
-            <xsl:with-param name="entity" select="$initiative"/>
-          </xsl:call-template>
-          -->
-        </div>
+
       </xsl:when>
       <xsl:otherwise>
-        The requested Instrument Initiative does not exist
+        <xsl:text> </xsl:text>
       </xsl:otherwise>
     </xsl:choose>
   </xsl:template>
 
   <xsl:template match="/">
-    <xsl:call-template name="instr_initiative">
+    <xsl:call-template name="instr_initiative_ws">
       <xsl:with-param name="admin" select="false()"/>
       <xsl:with-param name="root" select="/rdf:RDF"/>
     </xsl:call-template>

--- a/xslt/pub-common.xsl
+++ b/xslt/pub-common.xsl
@@ -100,7 +100,20 @@
   <xsl:template name="place-citation">
     <xsl:param name="doc"/>
 
-    <p>
+    <h3 style="margin-top: 0em; margin-bottom: 0em;">
+    <xsl:choose>
+      <xsl:when test="$doc/bibo:doi">
+        <xsl:variable name="doi" select="$doc/bibo:doi"/>
+        <a href="https://dx.doi.org/{$doi}"><xsl:value-of select="$doc/rdfs:label"/></a>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:variable name="docuri" select="$doc/@rdf:about"/>
+        <a href="{$docuri}"><xsl:value-of select="$doc/rdfs:label"/></a>
+      </xsl:otherwise>
+    </xsl:choose>
+    </h3>
+
+    <div>
     <xsl:call-template name="place-authors">
       <xsl:with-param name="doc" select="$doc"/>
     </xsl:call-template>
@@ -127,21 +140,23 @@
         <xsl:with-param name="doc" select="$doc"/>
       </xsl:call-template>
     </xsl:if>
-    </p>
+    </div>
 
   </xsl:template>
 
-  <xsl:template name="place-dco-citation">
+  <xsl:template name="place-dco-citations">
     <xsl:param name="node"/>
       <xsl:choose>
         <xsl:when test="$node/dco:associatedPublication">
           <p style="font-weight:bold;">Publications:</p>
+          <div id="findings" style="width:95%">
           <xsl:for-each select="key('bibo:Document-nodes',$node/dco:associatedPublication/@rdf:resource)">
             <xsl:sort select="rdfs:label"/>
             <xsl:call-template name="place-citation">
               <xsl:with-param name="doc" select="current()"/>
             </xsl:call-template>
           </xsl:for-each>
+          </div>
         </xsl:when>
         <xsl:otherwise>
           <p> </p>


### PR DESCRIPTION
Initially had one big xsl to display the whole page. Broke this apart to have many different xsl to allow for better control of the display. Also added the
inititive publications display.
